### PR TITLE
Allow .qmd files in detect_dependencies

### DIFF
--- a/R/detect_dependencies.R
+++ b/R/detect_dependencies.R
@@ -35,7 +35,7 @@ detect_dependencies <- function(file_path) {
       )
     )
 
-  if (!(file_type %in% c(".r", ".rmd"))) stop("detect_dependencies only supported for .R and .Rmd")
+  if (!(file_type %in% c(".r", ".rmd", ".qmd"))) stop("detect_dependencies only supported for .R and .Rmd")
 
   deps <- switch(file_type,
     .r = parse_detect_deps(file_path, parse),


### PR DESCRIPTION
This allows Quarto files to be parsed by `detect_dependencies`, primary to address https://github.com/MilesMcBain/capsule/issues/23 . In my own casual use, I have yet to run into issues with quarto files.

@MilesMcBain 